### PR TITLE
Fix literals in browser

### DIFF
--- a/build-browser-test.js
+++ b/build-browser-test.js
@@ -4,7 +4,7 @@ var path = require('path')
 
 browserify('./test/test.js').bundle().pipe(fs.createWriteStream('./test/support/browser-test.js'))
 
-fs.unlinkSync('./test/support/mocha.css')
-fs.unlinkSync('./test/support/mocha.js')
+fs.existsSync('./test/support/mocha.css') && fs.unlinkSync('./test/support/mocha.css')
+fs.existsSync('./test/support/mocha.js') && fs.unlinkSync('./test/support/mocha.js')
 fs.symlinkSync(path.join(path.dirname(require.resolve('mocha')), 'mocha.css'), './test/support/mocha.css')
 fs.symlinkSync(path.join(path.dirname(require.resolve('mocha')), 'mocha.js'), './test/support/mocha.js')

--- a/index.js
+++ b/index.js
@@ -584,7 +584,7 @@ RdfXmlParser.prototype.process = function (toparse, callback, base, filter, done
       var xmlString = '';
 
       for(var i=0; i<nodes.length; i++) {
-        xmlString += nodes[i].toString();
+        xmlString += nodes[i].nodeValue;
       }
 
       return xmlString;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "RDF/XML parser that follows the RDF Interface specification",
   "main": "index.js",
   "scripts": {
-    "test": "node_modules/.bin/mocha"
+    "test": "node_modules/.bin/mocha",
+    "browsertest": "node build-browser-test.js && open http://localhost:8000"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
     "rdf-parser-dom": "^0.3.0"
   },
   "devDependencies": {
+    "browserify": "^13.0.1",
     "mocha": "^2.3.3",
     "rdf-test-data": "^0.3.0",
     "rdf-test-utils": "^0.3.0"

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,13 @@ var simpleXml = '<?xml version="1.0" encoding="UTF-8"?>' +
     '</rdf:Description>' +
     '</rdf:RDF>';
 
+var xmlWithLiteral = '<?xml version="1.0" encoding="UTF-8"?>' +
+    '<rdf:RDF xmlns:e="http://example.org/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">' +
+    '<rdf:Description rdf:about="subject">' +
+    '<e:predicate rdf:parseType="Literal">txt</e:predicate>' +
+    '</rdf:Description>' +
+    '</rdf:RDF>';
+
 describe('RDF/XML parser', function () {
   describe('instance API', function () {
     describe('process', function () {
@@ -169,6 +176,23 @@ describe('RDF/XML parser', function () {
         })
       })
     })
+
+    describe('literal', function () {
+      it('should be supported', function (done) {
+        var parser = new RdfXmlParser()
+
+        parser.parse(xmlWithLiteral).then(function (graph) {
+          var textResult = graph._graph[0].object.toString();
+          if (textResult !== 'txt') {
+            done('wrong literal value')
+          } else {
+            done()
+          }
+        }).catch(function (error) {
+          done(error)
+        })
+      })
+    });
   })
 
   describe('static API', function () {
@@ -314,6 +338,23 @@ describe('RDF/XML parser', function () {
         })
       })
     })
+
+    describe('literal', function () {
+      it('should be supported', function (done) {
+        var parser = new RdfXmlParser()
+
+        parser.parse(xmlWithLiteral).then(function (graph) {
+          var textResult = graph._graph[0].object.toString();
+          if (textResult !== 'txt') {
+            done('wrong literal value')
+          } else {
+            done()
+          }
+        }).catch(function (error) {
+          done(error)
+        })
+      })
+      });
   })
 
   describe('example data', function () {


### PR DESCRIPTION
literal text subject/object returned "[Object Text]" instead of the text content, in chrome and firefox browser.
